### PR TITLE
Introduce HttpStatus enum and add test coverage

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -42,12 +42,6 @@ impl Headers {
         None
     }
 
-    /* For future use
-
-    pub fn delete(&mut self, name: &str) {
-        let _ = self.headers.remove(name);
-    }
-
     /// set clears all values associated with the given name and set
     /// its value to the singe value provided.
     pub fn set(&mut self, name: &str, value: &str) {
@@ -58,8 +52,15 @@ impl Headers {
                 coll.clear();
                 coll.push(String::from(value));
             })
-            .or_insert(Vec::from([String::from(value)]));
+            .or_insert_with(|| Vec::from([String::from(value)]));
     }
+
+    /* For future use
+
+    pub fn delete(&mut self, name: &str) {
+        let _ = self.headers.remove(name);
+    }
+
 
     */
 

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -1,50 +1,39 @@
-use crate::consts::{self, CRLF};
+#[cfg(test)]
+mod tests;
+
+mod status;
+
+use crate::consts::CRLF;
 use crate::header::Headers;
+use crate::response::status::HttpStatus;
 use anyhow::Result;
 use std::io::Write;
 
 #[derive(Debug)]
 pub struct Response {
-    status_code: String,
-    status_phrase: String,
+    status: HttpStatus,
     headers: Headers,
     body: Option<Vec<u8>>,
 }
 
 impl Response {
-    pub fn new(status_code: String, status_phrase: String) -> Self {
+    pub fn new(status: HttpStatus) -> Self {
         Self {
-            status_code,
-            status_phrase,
+            status,
             headers: Headers::new(),
             body: None,
         }
     }
 
-    pub fn with_body(body: &str) -> Self {
-        let mut headers = Headers::new();
-        headers.add("Content-Type", "text/plain");
-        headers.add("Content-Length", &body.len().to_string());
-
-        Self {
-            status_code: String::from("200"),
-            status_phrase: String::from("OK"),
-            headers,
-            body: Some(Vec::from(body.as_bytes())),
-        }
+    pub fn set_body(&mut self, body: &str) {
+        let bytes = body.as_bytes();
+        self.headers.set("Content-Type", "text/plain");
+        self.headers.set("Content-Length", &bytes.len().to_string());
+        self.body = Some(Vec::from(body.as_bytes()));
     }
 
     pub fn write(&self, stream: &mut impl Write) -> Result<()> {
-        let head = format!(
-            "{} {} {}",
-            consts::STR_HTTP_1_1,
-            self.status_code,
-            self.status_phrase
-        );
-
-        stream.write_all(head.as_bytes())?;
-        stream.write_all(CRLF)?;
-
+        self.status.write_request_line(stream)?;
         self.headers.write(stream)?;
 
         // empty line to separate body from headers
@@ -59,22 +48,19 @@ impl Response {
 }
 
 pub fn internal_err_response() -> Response {
-    Response::new(String::from("500"), String::from("Internal Server Error"))
+    Response::new(HttpStatus::InternalServerError)
 }
 
 pub fn bad_request(body: &str) -> Response {
-    Response {
-        status_code: String::from("400"),
-        status_phrase: String::from("Bad Request"),
-        headers: Headers::new(),
-        body: Some(Vec::from(body.as_bytes())),
-    }
+    let mut resp = Response::new(HttpStatus::BadRequest);
+    resp.set_body(body);
+    resp
 }
 
 pub fn ok() -> Response {
-    Response::new(String::from("200"), String::from("OK"))
+    Response::new(HttpStatus::Ok)
 }
 
 pub fn not_found() -> Response {
-    Response::new(String::from("404"), String::from("Not Found"))
+    Response::new(HttpStatus::NotFound)
 }

--- a/src/response/status.rs
+++ b/src/response/status.rs
@@ -1,0 +1,54 @@
+use crate::consts::{CRLF, SPACE};
+use anyhow::Result;
+
+const HTTP_1_1: &[u8] = b"HTTP/1.1";
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum HttpStatus {
+    Ok = 200,                  // 200
+    BadRequest = 400,          // 400
+    Unauthorized = 401,        // 401
+    Forbidden = 403,           // 403
+    NotFound = 404,            // 404
+    InternalServerError = 500, // 500
+}
+
+impl HttpStatus {
+    pub fn write_request_line(&self, stream: &mut impl std::io::Write) -> Result<()> {
+        // A request line of HTTP/1.1 looks like this
+        // HTTP/1.1 200 OK
+        // HTTP/1.1 404 Not Found
+
+        stream.write_all(HTTP_1_1)?; // default to HTTP 1.1 protocol
+        stream.write_all(SPACE)?;
+        stream.write_all(self.status_code().as_bytes())?;
+        stream.write_all(SPACE)?;
+        stream.write_all(self.status_phrase().as_bytes())?;
+        stream.write_all(CRLF)?;
+
+        Ok(())
+    }
+
+    const fn status_phrase(&self) -> &'static str {
+        match self {
+            Self::Ok => "OK",
+            Self::BadRequest => "Bad Request",
+            Self::Unauthorized => "Unauthorized",
+            Self::Forbidden => "Forbidden",
+            Self::NotFound => "Not Found",
+            Self::InternalServerError => "Internal Server Error",
+        }
+    }
+
+    const fn status_code(&self) -> &'static str {
+        match self {
+            Self::Ok => "200",
+            Self::BadRequest => "400",
+            Self::Unauthorized => "401",
+            Self::Forbidden => "403",
+            Self::NotFound => "404",
+            Self::InternalServerError => "500",
+        }
+    }
+}

--- a/src/response/tests.rs
+++ b/src/response/tests.rs
@@ -1,0 +1,191 @@
+use super::*;
+
+// Tests for Response::new()
+#[test]
+fn test_new_creates_response_with_status() {
+    let resp = Response::new(HttpStatus::Ok);
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert!(output.starts_with("HTTP/1.1 200 OK\r\n"));
+}
+
+#[test]
+fn test_new_response_has_no_body() {
+    let resp = Response::new(HttpStatus::Ok);
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    // Should end with empty line (header/body separator) and nothing after
+    assert!(output.ends_with("\r\n\r\n"));
+}
+
+// Tests for Response::set_body()
+#[test]
+fn test_set_body_adds_content() {
+    let mut resp = Response::new(HttpStatus::Ok);
+    resp.set_body("Hello, World!");
+
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert!(output.ends_with("Hello, World!"));
+}
+
+#[test]
+fn test_set_body_sets_content_type() {
+    let mut resp = Response::new(HttpStatus::Ok);
+    resp.set_body("test");
+
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert!(output.contains("Content-Type: text/plain\r\n"));
+}
+
+#[test]
+fn test_set_body_sets_content_length() {
+    let mut resp = Response::new(HttpStatus::Ok);
+    resp.set_body("Hello");
+
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert!(output.contains("Content-Length: 5\r\n"));
+}
+
+// Tests for Response::write()
+#[test]
+fn test_write_format_with_body() {
+    let mut resp = Response::new(HttpStatus::Ok);
+    resp.set_body("test body");
+
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+
+    // Check structure: status line, headers, empty line, body
+    assert!(output.starts_with("HTTP/1.1 200 OK\r\n"));
+    assert!(output.contains("\r\n\r\n")); // empty line separator
+    assert!(output.ends_with("test body"));
+}
+
+#[test]
+fn test_write_format_without_body() {
+    let resp = Response::new(HttpStatus::NotFound);
+
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert_eq!(output, "HTTP/1.1 404 Not Found\r\n\r\n");
+}
+
+// Tests for factory functions
+#[test]
+fn test_ok_returns_200() {
+    let resp = ok();
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert!(output.starts_with("HTTP/1.1 200 OK\r\n"));
+}
+
+#[test]
+fn test_not_found_returns_404() {
+    let resp = not_found();
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert!(output.starts_with("HTTP/1.1 404 Not Found\r\n"));
+}
+
+#[test]
+fn test_bad_request_returns_400_with_body() {
+    let resp = bad_request("Invalid input");
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert!(output.starts_with("HTTP/1.1 400 Bad Request\r\n"));
+    assert!(output.ends_with("Invalid input"));
+}
+
+#[test]
+fn test_internal_err_response_returns_500() {
+    let resp = internal_err_response();
+    let mut buffer = Vec::new();
+    resp.write(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert!(output.starts_with("HTTP/1.1 500 Internal Server Error\r\n"));
+}
+
+// Tests for HttpStatus::write_request_line()
+#[test]
+fn test_status_write_request_line_ok() {
+    let status = HttpStatus::Ok;
+    let mut buffer = Vec::new();
+    status.write_request_line(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert_eq!(output, "HTTP/1.1 200 OK\r\n");
+}
+
+#[test]
+fn test_status_write_request_line_bad_request() {
+    let status = HttpStatus::BadRequest;
+    let mut buffer = Vec::new();
+    status.write_request_line(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert_eq!(output, "HTTP/1.1 400 Bad Request\r\n");
+}
+
+#[test]
+fn test_status_write_request_line_unauthorized() {
+    let status = HttpStatus::Unauthorized;
+    let mut buffer = Vec::new();
+    status.write_request_line(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert_eq!(output, "HTTP/1.1 401 Unauthorized\r\n");
+}
+
+#[test]
+fn test_status_write_request_line_forbidden() {
+    let status = HttpStatus::Forbidden;
+    let mut buffer = Vec::new();
+    status.write_request_line(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert_eq!(output, "HTTP/1.1 403 Forbidden\r\n");
+}
+
+#[test]
+fn test_status_write_request_line_not_found() {
+    let status = HttpStatus::NotFound;
+    let mut buffer = Vec::new();
+    status.write_request_line(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert_eq!(output, "HTTP/1.1 404 Not Found\r\n");
+}
+
+#[test]
+fn test_status_write_request_line_internal_server_error() {
+    let status = HttpStatus::InternalServerError;
+    let mut buffer = Vec::new();
+    status.write_request_line(&mut buffer).unwrap();
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert_eq!(output, "HTTP/1.1 500 Internal Server Error\r\n");
+}

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -11,13 +11,17 @@ pub fn handle(req: &Request) -> Result<Response> {
 
     if req.path_match_prefix("/echo/") {
         let message = &req.path()?[6..];
-        let resp = Response::with_body(message);
+        let mut resp = response::ok();
+        resp.set_body(message);
         return Ok(resp);
     }
 
     if req.path_match_exact("/user-agent") {
         if let Some(value) = req.headers().get(consts::HEADER_USER_AGENT) {
-            return Ok(response::Response::with_body(value));
+            let mut resp = response::ok();
+            resp.set_body(value);
+
+            return Ok(resp);
         }
 
         return Ok(response::bad_request("missing user-agent header"));


### PR DESCRIPTION
## Summary

- Introduce `HttpStatus` enum to replace string-based status codes in HTTP responses
- Refactor `Response` struct to use the new enum for type-safe status handling
- Add comprehensive test coverage for `headers.set()` method (6 tests)
- Add comprehensive test coverage for the response module (17 tests)
- Fix clippy warnings: use `or_insert_with` for lazy evaluation, make functions `const`, use `Self::` in match arms

## Changes

### New Files
- `src/response/status.rs` - `HttpStatus` enum with variants: Ok (200), BadRequest (400), Unauthorized (401), Forbidden (403), NotFound (404), InternalServerError (500)
- `src/response/tests.rs` - 17 tests covering Response struct and factory functions

### Modified Files
- `src/response/mod.rs` - Refactored to use `HttpStatus` enum
- `src/header/mod.rs` - Fixed clippy warning (`or_insert` → `or_insert_with`)
- `src/header/tests.rs` - Added 6 tests for `headers.set()` method
- `src/router/mod.rs` - Updated to use new response API

## Test Plan

- [x] All 51 tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)