### PR TITLE
Refactor Request struct to use non-optional fields

### DIFF
--- a/src/http/tests.rs
+++ b/src/http/tests.rs
@@ -119,21 +119,27 @@ fn test_status_ok_write_status_line() {
 #[test]
 fn test_status_bad_request_write_status_line() {
     let mut buffer = Vec::new();
-    HttpStatus::BadRequest.write_status_line(&mut buffer).unwrap();
+    HttpStatus::BadRequest
+        .write_status_line(&mut buffer)
+        .unwrap();
     assert_eq!(buffer, b"HTTP/1.1 400 Bad Request\r\n");
 }
 
 #[test]
 fn test_status_unauthorized_write_status_line() {
     let mut buffer = Vec::new();
-    HttpStatus::Unauthorized.write_status_line(&mut buffer).unwrap();
+    HttpStatus::Unauthorized
+        .write_status_line(&mut buffer)
+        .unwrap();
     assert_eq!(buffer, b"HTTP/1.1 401 Unauthorized\r\n");
 }
 
 #[test]
 fn test_status_forbidden_write_status_line() {
     let mut buffer = Vec::new();
-    HttpStatus::Forbidden.write_status_line(&mut buffer).unwrap();
+    HttpStatus::Forbidden
+        .write_status_line(&mut buffer)
+        .unwrap();
     assert_eq!(buffer, b"HTTP/1.1 403 Forbidden\r\n");
 }
 
@@ -147,7 +153,9 @@ fn test_status_not_found_write_status_line() {
 #[test]
 fn test_status_internal_server_error_write_status_line() {
     let mut buffer = Vec::new();
-    HttpStatus::InternalServerError.write_status_line(&mut buffer).unwrap();
+    HttpStatus::InternalServerError
+        .write_status_line(&mut buffer)
+        .unwrap();
     assert_eq!(buffer, b"HTTP/1.1 500 Internal Server Error\r\n");
 }
 

--- a/src/request/tests.rs
+++ b/src/request/tests.rs
@@ -9,7 +9,7 @@ fn test_from_reader_simple_get() {
 
     let request = from_reader(&mut reader).expect("should parse request");
 
-    assert_eq!(request.path().unwrap(), "/");
+    assert_eq!(request.path(), "/");
 }
 
 #[test]
@@ -20,7 +20,7 @@ fn test_from_reader_simple_get_long_path() {
     let request = from_reader(&mut reader).expect("should parse request");
 
     assert_eq!(
-        request.path().unwrap(),
+        request.path(),
         "/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     );
 }

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -21,7 +21,7 @@ impl Router {
         }
 
         if req.path_match_prefix("/echo/") {
-            let message = &req.path()?[6..];
+            let message = &req.path()[6..];
             let mut resp = response::ok();
             resp.set_str_body(message);
             return Ok(resp);
@@ -39,7 +39,7 @@ impl Router {
         }
 
         if req.path_match_prefix("/files") {
-            let path = &req.path()?[7..];
+            let path = &req.path()[7..];
             if path.contains("..") || path.starts_with('/') {
                 return Ok(response::Response::new(HttpStatus::Forbidden));
             }


### PR DESCRIPTION
## Summary
- Refactor `Request` struct to use `HttpMethod` and `String` directly instead of `Option<T>` wrappers
- Simplify request parsing logic with a cleaner `match` pattern that separates request line parsing from header parsing
- Update `path()` to return `&str` directly instead of `Result<&str>`
- Simplify path matching methods by removing unnecessary `Option` checks

## Test plan
- [x] All 77 existing tests pass
- [x] No clippy warnings
- [x] Code formatted with `cargo fmt`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)