### PR TITLE
Add HTTP request body parsing and file upload support

### DIFF
--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+
+#[derive(Debug)]
+pub enum HttpBody {
+    Empty,
+    #[allow(dead_code)]
+    Content(Vec<u8>),
+}
+
+impl HttpBody {
+    /// `new` creates an `HttpBody`
+    pub fn read<F>(read: Option<&[u8]>, content_len: usize, stream: &mut F) -> Result<Self>
+    where
+        F: std::io::Read,
+    {
+        // allocate a vector for return data
+        let mut data: Vec<u8> = read.map_or_else(
+            || Vec::with_capacity(content_len),
+            |data| {
+                let mut retval = Vec::with_capacity(content_len);
+                retval.extend_from_slice(data);
+                retval
+            },
+        );
+
+        let mut remaining = content_len - data.len();
+        let mut buf = [0; 1024];
+        while remaining > 0 {
+            // the amount of data to read is capped at 1024
+            let read_len: usize = if remaining < 1024 { remaining } else { 1024 };
+            stream.read_exact(&mut buf[0..read_len])?;
+
+            remaining -= read_len;
+            data.extend_from_slice(&buf[0..read_len]);
+        }
+
+        if data.is_empty() {
+            return Ok(Self::Empty);
+        }
+
+        Ok(Self::Content(data))
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/src/body/test.rs
+++ b/src/body/test.rs
@@ -1,0 +1,95 @@
+use super::*;
+use std::io::Cursor;
+
+#[test]
+fn test_content_length_condition() {}
+
+#[test]
+fn test_read_empty_body() {
+    let mut stream = Cursor::new(Vec::new());
+    let result = HttpBody::read(None, 0, &mut stream).unwrap();
+    assert!(matches!(result, HttpBody::Empty));
+}
+
+#[test]
+fn test_read_body_from_stream_only() {
+    let content = b"Hello, World!";
+    let mut stream = Cursor::new(content.to_vec());
+    let result = HttpBody::read(None, content.len(), &mut stream).unwrap();
+
+    match result {
+        HttpBody::Content(data) => assert_eq!(data, content.to_vec()),
+        HttpBody::Empty => panic!("Expected Content, got Empty"),
+    }
+}
+
+#[test]
+fn test_read_body_with_preread_data() {
+    let preread = b"Hello, ";
+    let remaining = b"World!";
+    let mut stream = Cursor::new(remaining.to_vec());
+    let total_len = preread.len() + remaining.len();
+
+    let result = HttpBody::read(Some(preread), total_len, &mut stream).unwrap();
+
+    match result {
+        HttpBody::Content(data) => assert_eq!(data, b"Hello, World!".to_vec()),
+        HttpBody::Empty => panic!("Expected Content, got Empty"),
+    }
+}
+
+#[test]
+fn test_read_body_all_preread() {
+    let preread = b"All preread data";
+    let mut stream = Cursor::new(Vec::new());
+
+    let result = HttpBody::read(Some(preread), preread.len(), &mut stream).unwrap();
+
+    match result {
+        HttpBody::Content(data) => assert_eq!(data, preread.to_vec()),
+        HttpBody::Empty => panic!("Expected Content, got Empty"),
+    }
+}
+
+#[test]
+fn test_read_large_body_multiple_chunks() {
+    // Create content larger than 1024 bytes to test chunked reading
+    let content: Vec<u8> = (0..2500).map(|i| (i % 256) as u8).collect();
+    let mut stream = Cursor::new(content.clone());
+
+    let result = HttpBody::read(None, content.len(), &mut stream).unwrap();
+
+    match result {
+        HttpBody::Content(data) => assert_eq!(data, content),
+        HttpBody::Empty => panic!("Expected Content, got Empty"),
+    }
+}
+
+#[test]
+fn test_read_exactly_1024_bytes() {
+    let content: Vec<u8> = (0..1024).map(|i| (i % 256) as u8).collect();
+    let mut stream = Cursor::new(content.clone());
+
+    let result = HttpBody::read(None, content.len(), &mut stream).unwrap();
+
+    match result {
+        HttpBody::Content(data) => assert_eq!(data, content),
+        HttpBody::Empty => panic!("Expected Content, got Empty"),
+    }
+}
+
+#[test]
+fn test_read_stream_error() {
+    // A reader that always returns an error
+    struct ErrorReader;
+    impl std::io::Read for ErrorReader {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(std::io::ErrorKind::Other, "test error"))
+        }
+    }
+
+    let mut stream = ErrorReader;
+    let result = HttpBody::read(None, 10, &mut stream);
+
+    assert!(result.is_err());
+}

--- a/src/consts/mod.rs
+++ b/src/consts/mod.rs
@@ -6,3 +6,5 @@ pub const SPACE: &[u8] = b" ";
 pub const STR_HTTP_1_1: &str = "HTTP/1.1";
 
 pub const HEADER_USER_AGENT: &str = "User-Agent";
+pub const HEADER_CONTENT_LENGTH: &str = "Content-Length";
+pub const HEADER_CONTENT_TYPE: &str = "Content-Type";

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -90,6 +90,27 @@ impl Headers {
 
         Err(anyhow!("invalid header bytes"))
     }
+
+    /// returns the value of Content-Length header in usize type.
+    /// - if the header is missing, returns zero.
+    /// - if the header is not missing but it can't be correctly parsed
+    ///   into usize, error is returned.
+    pub fn content_length(&self) -> Result<usize> {
+        self.get(consts::HEADER_CONTENT_LENGTH).map_or_else(
+            || Ok(0),
+            |header| {
+                header
+                    .parse::<usize>()
+                    .map_err(|_e| anyhow!("failed to parse Content-Length"))
+            },
+        )
+    }
+
+    /// returns the value of Content-Type header as &str.
+    /// returns None if the header is not present.
+    pub fn content_type(&self) -> Option<&str> {
+        self.get(consts::HEADER_CONTENT_TYPE)
+    }
 }
 
 fn wire_format(name: &String, values: &[String]) -> Vec<u8> {

--- a/src/header/tests.rs
+++ b/src/header/tests.rs
@@ -352,3 +352,131 @@ fn test_set_multiple_different_headers() {
     assert_eq!(headers.get("content-type"), Some("application/json"));
     assert_eq!(headers.get("accept"), Some("text/html"));
 }
+
+// Tests for content_length() method
+#[test]
+fn test_content_length_returns_value_when_present() {
+    let mut headers = Headers::new();
+    headers.add("Content-Length", "42");
+
+    assert_eq!(headers.content_length().unwrap(), 42);
+}
+
+#[test]
+fn test_content_length_returns_zero_when_absent() {
+    let headers = Headers::new();
+
+    assert_eq!(headers.content_length().unwrap(), 0);
+}
+
+#[test]
+fn test_content_length_returns_error_for_invalid_number() {
+    let mut headers = Headers::new();
+    headers.add("Content-Length", "not-a-number");
+
+    assert!(headers.content_length().is_err());
+}
+
+#[test]
+fn test_content_length_returns_error_for_negative_number() {
+    let mut headers = Headers::new();
+    headers.add("Content-Length", "-10");
+
+    assert!(headers.content_length().is_err());
+}
+
+#[test]
+fn test_content_length_returns_error_for_float() {
+    let mut headers = Headers::new();
+    headers.add("Content-Length", "3.14");
+
+    assert!(headers.content_length().is_err());
+}
+
+#[test]
+fn test_content_length_returns_zero_for_zero() {
+    let mut headers = Headers::new();
+    headers.add("Content-Length", "0");
+
+    assert_eq!(headers.content_length().unwrap(), 0);
+}
+
+#[test]
+fn test_content_length_large_value() {
+    let mut headers = Headers::new();
+    headers.add("Content-Length", "1073741824"); // 1 GB
+
+    assert_eq!(headers.content_length().unwrap(), 1073741824);
+}
+
+#[test]
+fn test_content_length_case_insensitive() {
+    let mut headers = Headers::new();
+    headers.add("content-length", "100");
+
+    assert_eq!(headers.content_length().unwrap(), 100);
+}
+
+#[test]
+fn test_content_length_from_read() {
+    let mut headers = Headers::new();
+    headers.read(b"Content-Length: 256").unwrap();
+
+    assert_eq!(headers.content_length().unwrap(), 256);
+}
+
+#[test]
+fn test_content_length_with_whitespace() {
+    let mut headers = Headers::new();
+    headers.read(b"Content-Length:   512   ").unwrap();
+
+    assert_eq!(headers.content_length().unwrap(), 512);
+}
+
+// Tests for content_type() method
+#[test]
+fn test_content_type_returns_value_when_present() {
+    let mut headers = Headers::new();
+    headers.add("Content-Type", "application/json");
+
+    assert_eq!(headers.content_type(), Some("application/json"));
+}
+
+#[test]
+fn test_content_type_returns_none_when_absent() {
+    let headers = Headers::new();
+
+    assert_eq!(headers.content_type(), None);
+}
+
+#[test]
+fn test_content_type_case_insensitive() {
+    let mut headers = Headers::new();
+    headers.add("content-type", "text/html");
+
+    assert_eq!(headers.content_type(), Some("text/html"));
+}
+
+#[test]
+fn test_content_type_from_read() {
+    let mut headers = Headers::new();
+    headers.read(b"Content-Type: text/plain").unwrap();
+
+    assert_eq!(headers.content_type(), Some("text/plain"));
+}
+
+#[test]
+fn test_content_type_with_charset() {
+    let mut headers = Headers::new();
+    headers.add("Content-Type", "text/html; charset=utf-8");
+
+    assert_eq!(headers.content_type(), Some("text/html; charset=utf-8"));
+}
+
+#[test]
+fn test_content_type_with_whitespace() {
+    let mut headers = Headers::new();
+    headers.read(b"Content-Type:   application/xml   ").unwrap();
+
+    assert_eq!(headers.content_type(), Some("application/xml"));
+}

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -7,10 +7,13 @@ const HTTP_1_1: &[u8] = b"HTTP/1.1";
 #[allow(dead_code)]
 pub enum HttpStatus {
     Ok = 200,                  // 200
+    Created = 201,             // 201
+    NoContent = 204,           // 204
     BadRequest = 400,          // 400
     Unauthorized = 401,        // 401
     Forbidden = 403,           // 403
     NotFound = 404,            // 404
+    MethodNotAllowed = 405,    // 405
     InternalServerError = 500, // 500
 }
 
@@ -33,10 +36,13 @@ impl HttpStatus {
     const fn status_phrase(&self) -> &'static str {
         match self {
             Self::Ok => "OK",
+            Self::Created => "Created",
+            Self::NoContent => "No Content",
             Self::BadRequest => "Bad Request",
             Self::Unauthorized => "Unauthorized",
             Self::Forbidden => "Forbidden",
             Self::NotFound => "Not Found",
+            Self::MethodNotAllowed => "Method Not Allowed",
             Self::InternalServerError => "Internal Server Error",
         }
     }
@@ -44,10 +50,13 @@ impl HttpStatus {
     const fn status_code(&self) -> &'static str {
         match self {
             Self::Ok => "200",
+            Self::Created => "201",
+            Self::NoContent => "204",
             Self::BadRequest => "400",
             Self::Unauthorized => "401",
             Self::Forbidden => "403",
             Self::NotFound => "404",
+            Self::MethodNotAllowed => "405",
             Self::InternalServerError => "500",
         }
     }

--- a/src/http/tests.rs
+++ b/src/http/tests.rs
@@ -166,8 +166,18 @@ fn test_status_debug() {
 }
 
 #[test]
+fn test_status_no_content_write_status_line() {
+    let mut buffer = Vec::new();
+    HttpStatus::NoContent
+        .write_status_line(&mut buffer)
+        .unwrap();
+    assert_eq!(buffer, b"HTTP/1.1 204 No Content\r\n");
+}
+
+#[test]
 fn test_status_enum_values() {
     assert_eq!(HttpStatus::Ok as u16, 200);
+    assert_eq!(HttpStatus::NoContent as u16, 204);
     assert_eq!(HttpStatus::BadRequest as u16, 400);
     assert_eq!(HttpStatus::Unauthorized as u16, 401);
     assert_eq!(HttpStatus::Forbidden as u16, 403);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod body;
 mod consts;
 mod file;
 mod header;


### PR DESCRIPTION
## Summary

This PR adds support for parsing HTTP request bodies and enables file uploads via POST requests to the `/files/*` endpoint.

### Changes

- **New `HttpBody` module** (`src/body/mod.rs`): Handles reading HTTP request bodies from streams with support for chunked reading and pre-read buffer data
- **File saving functionality**: Added `FileSaver` trait and `FileSaverError` enum to the file module, with `LocalFileSystem` implementation for writing files to disk
- **New HTTP status codes**: Added `Created` (201), `NoContent` (204), and `MethodNotAllowed` (405) to `HttpStatus` enum
- **Header helpers**: Added `content_length()` and `content_type()` methods to `Headers` for parsing common request headers
- **Request body parsing**: Extended `Request` struct to include body field and updated `from_reader` to parse request bodies based on `Content-Length` header
- **Router POST endpoint**: `/files/*` now supports both GET (retrieve) and POST (save) methods with proper content-type validation

### API

- `POST /files/<path>` - Save file content (requires `Content-Type: application/octet-stream`)
- `GET /files/<path>` - Retrieve file content (existing functionality)

## Test plan

- [x] Unit tests for `HttpBody::read` with various scenarios (empty, partial, large bodies)
- [x] Unit tests for `content_length()` and `content_type()` header methods
- [x] Integration tests for request parsing with body content
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)